### PR TITLE
Fix "Cannot find module" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://github.com/niftylettuce/react-native-loading-spinner-overlay",
   "devDependencies": {
-    "autobind-decorator": "^1.3.3",
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
     "babel-eslint": "^4.1.6",
@@ -52,6 +51,7 @@
     "jshint": "^2.8.0"
   },
   "dependencies": {
+    "autobind-decorator": "^1.3.3",
     "react-native-gifted-spinner": "0.0.3"
   }
 }


### PR DESCRIPTION
When installing react-native-loading-spinner-overlay, autobind-decorator isn't installed because it's listed in devDependencies. I moved it to dependencies.