### PR TITLE
Add condition for closing Portal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export default class Spinner extends React.Component {
     if (!prevProps.visible && this.props.visible)
       return Portal.showModal(tag, this._renderSpinner());
 
-    Portal.closeModal(tag);
+    if (prevProps.visible && !this.props.visible) Portal.closeModal(tag);
 
   }
 


### PR DESCRIPTION
On android Portal modal closes after any update.
It should close only when `visible` prop is changed

Fixes #3